### PR TITLE
[2.x] FIX: upgrade SimpleWebAuthn for userHandle compatibility with webauthn.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
-        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/browser": "^10.0.0",
         "ofetch": "^1.3.3"
       },
       "devDependencies": {
@@ -1029,17 +1029,17 @@
       ]
     },
     "node_modules/@simplewebauthn/browser": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-9.0.1.tgz",
-      "integrity": "sha512-wD2WpbkaEP4170s13/HUxPcAV5y4ZXaKo1TfNklS5zDefPinIgXOpgz1kpEvobAsaLPa2KeH7AKKX/od1mrBJw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-10.0.0.tgz",
+      "integrity": "sha512-hG0JMZD+LiLUbpQcAjS4d+t4gbprE/dLYop/CkE01ugU/9sKXflxV5s0DRjdz3uNMFecatRfb4ZLG3XvF8m5zg==",
       "dependencies": {
-        "@simplewebauthn/types": "^9.0.1"
+        "@simplewebauthn/types": "^10.0.0"
       }
     },
     "node_modules/@simplewebauthn/types": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@simplewebauthn/types/-/types-9.0.1.tgz",
-      "integrity": "sha512-tGSRP1QvsAvsJmnOlRQyw/mvK9gnPtjEc5fg2+m8n+QUa+D7rvrKkOYyfpy42GTs90X3RDOnqJgfHt+qO67/+w=="
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/types/-/types-10.0.0.tgz",
+      "integrity": "sha512-SFXke7xkgPRowY2E+8djKbdEznTVnD5R6GO7GPTthpHrokLvNKw8C3lFZypTxLI7KkCfGPfhtqB3d7OVGGa9jQ=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "license": "MIT",
   "dependencies": {
     "ofetch": "^1.3.3",
-    "@simplewebauthn/browser": "^9.0.1"
+    "@simplewebauthn/browser": "^10.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",


### PR DESCRIPTION
<!--
Thanks for contributing to this package! We only accept PR to the latest stable version.

If you're pushing a Feature:
- Title it: "[X.x] This new feature"
- Describe what the new feature enables
- Show a small code snippet of the new feature
- Ensure it doesn't break backward compatibility.

If you're pushing a Fix:
- Title it: "[X.x] FIX: The bug name"
- Describe how it fixes in a few words.
- Ensure it doesn't break backward compatibility.

All Pull Requests run with extensive tests for stable and latest versions of PHP and Laravel. 
Ensure your tests pass or your PR may be taken down.

If you're a Sponsor, this PR will have priority review.
Not a Sponsor? Become one at https://github.com/sponsors/DarkGhostHunter
-->

# Description

Laragear/WebAuthn's old webauthn.js helper encodes/decodes the userHandle value with base64, however the version of SimpleWebAuthn/browser this helper uses, uses TextEncoder instead, which means keys created using the old webauthn.js helper aren't compatible with this library.

SimpleWebAuthn v10 uses base64 encoding like the old helper, and so this PR upgrades SWA in order to allow easy migration to Webpass.

https://github.com/Laragear/WebAuthn/pull/94 should be merged at the same time as this, as it allows compatibility between any credentials created with TextEncoder that are subsequently read with base64.
